### PR TITLE
add architecture targeting for armv8-a

### DIFF
--- a/images/base-linuxarm64/Dockerfile
+++ b/images/base-linuxarm64/Dockerfile
@@ -59,8 +59,8 @@ ENV PATH="/opt/ct-ng/bin:${PATH}" \
     AR="${FFBUILD_TOOLCHAIN}-gcc-ar" \
     RANLIB="${FFBUILD_TOOLCHAIN}-gcc-ranlib" \
     NM="${FFBUILD_TOOLCHAIN}-gcc-nm" \
-    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -pthread" \
-    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -pthread" \
-    LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffbuild/lib -O2 -pipe -fstack-protector-strong -fstack-clash-protection -Wl,-z,relro,-z,now -pthread -lm" \
+    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -march=armv8-a -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -pthread" \
+    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -march=armv8-a -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -pthread" \
+    LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffbuild/lib -O2 -pipe -march=armv8-a -fstack-protector-strong -fstack-clash-protection -Wl,-z,relro,-z,now -pthread -lm" \
     STAGE_CFLAGS="-fvisibility=hidden -fno-semantic-interposition" \
     STAGE_CXXFLAGS="-fvisibility=hidden -fno-semantic-interposition"


### PR DESCRIPTION
Added -march=armv8-a to linuxarm64 compiler flags. This provides a small improvement in execution speed on Rockchip 3566 (and presumably 3588) by vectorising code using NEON. This benefit is approx 3.5% for rkmpp hardware decoding. Armv8-a was chosen to limit the risk of breaking compatibility with other Arm64 targets,  e.g. if this is installed on a non-rk Arm64 board (35xx series are Armv8.2-a). There is no significant measured difference in decoding speed between an v8 and v8.2 target.
Note: tested on a Radxa Zero3 2gb.